### PR TITLE
Fixed the location header expect to use && instead of ||

### DIFF
--- a/index.js
+++ b/index.js
@@ -152,8 +152,8 @@ Test = comb.define(null, {
                                 if (header === "location") {
                                     var actual = headers[header];
                                     if (!comb.deepEqual(actual, val)
-                                        || !comb.deepEqual(actual, this._baseUrl + val)
-                                        || !comb.deepEqual(actual, this._baseUrl.replace(/^http[s]?:/, "") + val)) {
+                                        && !comb.deepEqual(actual, this._baseUrl + val)
+                                        && !comb.deepEqual(actual, this._baseUrl.replace(/^http[s]?:/, "") + val)) {
                                         throw new Error([
                                             'Expected "', expect[1], '" of "' + val, '", got "', headers[header], '"'
                                         ].join(""));


### PR DESCRIPTION
I was doing an OR when it should be doing an AND.
