### PR TITLE
Fix RegExp expect for headers.

### DIFF
--- a/index.js
+++ b/index.js
@@ -158,8 +158,10 @@ Test = comb.define(null, {
                     var header = expect[1].toLowerCase();
                     val = expect[2];
                     if (header in headers) {
-                        if (comb.isRexExp(val) && !val.test(headers[header])) {
-                            throw new Error('Expected "' + expect[1] + '" matching ' + val + ', got "' + headers[header] + '"' + "\n" + expect[3]);
+                        if (comb.isRexExp(val)) {
+                            if (!val.test(headers[header])) {
+                                throw new Error('Expected "' + expect[1] + '" matching ' + val + ', got "' + headers[header] + '"' + "\n" + expect[3]);
+                            }
                         } else {
                             if (header === "location") {
                                 var actual = headers[header];

--- a/test/request.test.js
+++ b/test/request.test.js
@@ -462,6 +462,19 @@ it.describe("request", function (it) {
 
                 request(app)
                     .get('/')
+                    .expect('Content-Type', /^text\/html/)
+                    .end(done);
+            });
+
+            it.should('should support failing regular expressions', function (done) {
+                var app = express();
+
+                app.get('/', function (req, res) {
+                    res.send('hey');
+                });
+
+                request(app)
+                    .get('/')
                     .expect('Content-Type', /^application/)
                     .end(function (err) {
                         var expectedMessage = 'Expected "Content-Type" matching /^application/, got "text/html; charset=utf-8"';


### PR DESCRIPTION
Only failing assertions were tested (which did work), but the success
case wasn't.

Fixes https://github.com/doug-martin/super-request/issues/7
