### PR TITLE
capture stack trace after customizing prepareStackTrace

### DIFF
--- a/index.js
+++ b/index.js
@@ -90,12 +90,11 @@ Test = comb.define(null, {
         expect: function (field, val, cb) {
             var self = this;
             var dummyObject = {};
-            Error.captureStackTrace(dummyObject, self.expect);
-
             var v8Handler = Error.prepareStackTrace;
             Error.prepareStackTrace = function (dummyObject, v8StackTrace) {
                 return v8StackTrace;
             };
+            Error.captureStackTrace(dummyObject, self.expect);
 
             var stack = dummyObject.stack;
             Error.prepareStackTrace = v8Handler;


### PR DESCRIPTION
I have upgraded my application to node 7.8.0 and all of the sudden most of my tests run with mocha which use `super-request` started to fail with this stack trace:
```
     TypeError: stack[0].getFileName is not a function
      at defineConstructor.expect (node_modules/super-request/index.js:102:43)
      at Context.<anonymous> (api/multiplier/routes_tests.js:87:10)
```

I tried a few 7.x versions including the first 7.0.0 and they all gave same error. Once I switched to 6.10.2 (also tried with 6.5.0 and the app was running fine prior on some 5.x version) the error disappeared and the tests started to pass with no errors thrown.

By debugging the `super-request` node_module I found out that on node versions 7.x the customized `Error.prepareStackTrace` method is not called at all. This means that instead of having an array of `CallSite` objects assigned to `dummyObject.stack` it contains a string (with a stack).

I have narrowed down the scope of the problem and created a little `stack.js` node script:
```
var dummyObject = {};
Error.captureStackTrace(dummyObject);
var v8Handler = Error.prepareStackTrace;
Error.prepareStackTrace = function (dummyObject, v8StackTrace) {
  console.log('returning v8stacktrace');
  return v8StackTrace;
};
var stack = dummyObject.stack;
console.log(stack);
Error.prepareStackTrace = v8Handler;
```

Console loging `dummyObject.stack` will give us

in node 6.x:
```
[ CallSite {},
  CallSite {},
  CallSite {},
  CallSite {},
  CallSite {},
  CallSite {},
  CallSite {},
  CallSite {},
  CallSite {},
  CallSite {} ]
```

in node 7.x
```
Error
    at Object.<anonymous> (/Users/jedrek/stack.js:2:7)
    at Module._compile (module.js:573:32)
    at Object.Module._extensions..js (module.js:582:10)
    at Module.load (module.js:490:32)
    at tryModuleLoad (module.js:449:12)
    at Function.Module._load (module.js:441:3)
    at Module.runMain (module.js:607:10)
    at run (bootstrap_node.js:382:7)
    at startup (bootstrap_node.js:137:9)
    at bootstrap_node.js:497:3
```

Moving `Error.captureStackTrace(dummyObject);` after `Error.prepareStackTrace = function(...`  in a simillar fashion as in this PR fixes the problem for node 7.x  and we get an array of `CallSite` objects again since our `prepareStackTrace` custom method is invoked again.

I did not do much research on why is that - if I understood correctly the `prepareStackTrace` method was called when the `stack` property was accessed and now it is simply called  when we invoke `captureStackTrace`. I might be wrong here though so feel free to correct me. This way or the other please have a look at the solution proposed for the 7.x node version.